### PR TITLE
Fix tracking of third-party group switching

### DIFF
--- a/src/libkbdd.c
+++ b/src/libkbdd.c
@@ -415,8 +415,10 @@ _on_xkbEvent(XkbEvent ev)
             Window focused_win;
             int revert;
             _get_active_window_fallback(ev.any.display, &focused_win);
-            if (grp == ev.state.locked_group) //do not save layout with modifier
+            if (grp == ev.state.locked_group) { //do not save layout with modifier
+                _kbdd.prevGroup = grp;
                 _kbdd_update_window_layout( focused_win, grp);
+            }
             break;
         case XkbNewKeyboardNotify:
             dbg("kbdnotify %u\n",ev.any.xkb_type);


### PR DESCRIPTION
After noting that group has been switched by third-party keyboard layout
switcher, kbdd didn't mirror this fact in one of its' internal state
variables. This state varible is used to prevent excessive group locking, so
then kbdd was errorneously refusing to properly handle its own switching
command.

Example:

  - third-party layout switcher makes switch from group 0 to group 1
  - kbdd doesn't mirror this fact in its' internal state
  - kbdd still thinks: last change was from some group to group 0
  - and so when kbdd will receive `set_layout(0)` command, it will not
    really perform switch back to group 0