### PR TITLE
Fix: declaration conflicting types for ‘kbdd_default_loop’

### DIFF
--- a/src/libkbdd.h
+++ b/src/libkbdd.h
@@ -57,7 +57,7 @@ uint32_t kbdd_get_current_layout(void);
 /**
  * default main loop that need to make xkbd working
  */
-void * kbdd_default_loop();
+void * kbdd_default_loop(Display * display);
 
 int kbdd_default_iter(void *);
 


### PR DESCRIPTION

`make` was unable to build the executable file due to the following conflicting types error:

libkbdd.c:223:1: error: conflicting types for ‘kbdd_default_loop’; have ‘void *(Display *)’
  223 | kbdd_default_loop(Display * display)
      | ^~~~~~~~~~~~~~~~~

In file included from libkbdd.c:29:
libkbdd.h:60:8: note: previous declaration of ‘kbdd_default_loop’ with type ‘void *(void)’
   60 | void * kbdd_default_loop();
      |        ^~~~~~~~~~~~~~~~~

fix was trivial, please approve it in order to allow usage of the program in Arch-based distros with automatic build tools from the AUR.



